### PR TITLE
Revert "GkcoiScreen: gkcoi の flat テーマに対応"

### DIFF
--- a/packages/site/src/components/organisms/GkcoiScreen/GkcoiScreen.tsx
+++ b/packages/site/src/components/organisms/GkcoiScreen/GkcoiScreen.tsx
@@ -22,7 +22,6 @@ const THEME_NAMES: Record<GkcoiTheme, string> = {
   "light-ex": "遠征 light-ex",
   white: "White",
   official: "公式 official",
-  flat: "Flat",
   "74lc": "七四式(大型) 74lc",
   "74mc": "七四式(中型) 74mc",
   "74sb": "七四式(小型) 74sb",


### PR DESCRIPTION
## 概要

`2b58fc17` で `THEME_NAMES` に追加した `flat` を戻す。develop の `next build` が型エラーで失敗する状態になっていた。

## 詳細

`gkcoi` は `package.json` で `^1.5.2`、`yarn.lock` で `1.5.2` に固定されている。この版の `Theme` 型は以下で、`flat` を含まない。

```ts
export type Theme = "dark" | "dark-ex" | "light" | "light-ex" | "white" | "74lc" | "74mc" | "74sb" | "official";
```

そのため `Record<GkcoiTheme, string>` に `flat` を足すと `TS2353` になる。

`flat` テーマを扱うには `gkcoi` 1.7 系への更新が別途必要で、それは本 PR の範囲外。

## 確認

`gkcoi 1.5.2`(committed な lockfile どおり)の状態で実行:

| コマンド | 結果 |
|---|---|
| `yarn tsc --noEmit` | exit 0 |
| `yarn eslint --cache packages` | exit 0 |
| `yarn jest` | exit 0 / 13 suites・69 tests passed |
| `yarn next build` | exit 0 / 23 ページ生成 |
