### PR TITLE
ISR 再生成時に翻訳が空になり全ロケールが英語表示になる問題を修正

### DIFF
--- a/packages/site/next.config.js
+++ b/packages/site/next.config.js
@@ -46,6 +46,13 @@ const config = {
   reactStrictMode: true,
   transpilePackages: ["ts-norm"],
 
+  // next-i18next の翻訳 JSON は実行時に動的パスで読まれるため nft が追跡できない。
+  // ISR の再生成は Serverless Function 内で getStaticProps を再実行するので、
+  // 明示的に同梱しないと翻訳が空になりキー(英語)がそのまま表示される。
+  outputFileTracingIncludes: {
+    "/": ["./public/locales/**"],
+  },
+
   images: {
     minimumCacheTTL: 2678400,
     qualities: [75],


### PR DESCRIPTION
## 概要

全ロケールで UI が英語表示になる問題を修正する。原因は言語切り替えではなく、ISR 再生成時に翻訳リソースが空になり `t()` がキーをそのまま返していたこと。キー自体が英単語(`Undo` / `Ship` / `Equipment` など)のため、英語 UI に見えていた。

## 詳細

### 症状

本番 (`jervis.vercel.app`) の `__NEXT_DATA__`:

```
/ (ja)  store[ja]: common=0, gears=0, gear_types=0, ships=0, stype=0, ctype=0
/en     store[en]: すべて 0
<title> = "meta.title - jervis.vercel.app"
```

### 原因

next-i18next は翻訳 JSON を実行時に動的パスで読むため @vercel/nft が追跡できず、`public/locales/**` が Serverless Function に同梱されない。ISR (`revalidate: 3600`) の再生成は lambda 内で `getStaticProps` を再実行するため、そこで翻訳リソースが空になる。

466b8e49 で `localePath` を `path.resolve("./public/locales")` から相対文字列へ変更した際に、nft がディレクトリを静的検出する経路が失われたのが起点。nft を直接実行した実測:

| localePath の形 | traced files | うち locales |
|---|---|---|
| `"./public/locales"` | 1 | 0 |
| `path.resolve("./public/locales")` | 31 | 30 |

`localePath` を絶対パスに戻す選択は取らない。`serializeConfig` が既定 true のため `localePath` は全ページの props にシリアライズされ、ビルド機と lambda で値が変わって ISR の内容が不安定になる — 466b8e49 が解消した問題そのものになる。相対のまま据え置き、`outputFileTracingIncludes` で同梱を明示する。将来のリファクタで nft の暗黙検出が再び失われても影響を受けない。

### 影響範囲

466b8e49 のデプロイ後、最初の ISR 再生成以降ずっと全ロケールが英語表示になる。デプロイ直後だけはビルド時プリレンダが配信されるため正常に見える。

Cloudflare 版 (`fleethub.madonoharu.workers.dev`) は純 SSG のため影響を受けておらず、`store[ja]: common=227, ctype=310` / title `作戦室` を返す。

### 検証

`next build` 後の `.next/server/pages/index.js.nft.json` に `public/locales` の 30 ファイルが含まれる(変更前は 0 件)。ビルド時プリレンダは変更前後とも正常(`ja: common=227, gear_types=97, stype=66, ctype=310`, title `作戦室`)。

ローカルビルドで確認できるのは nft のトレースまでで、Vercel の lambda パッケージングと実行時挙動は未検証。デプロイ後の確認は ISR 再生成が起きる 1 時間後に行う(直後はビルド時プリレンダが配信されるため判別できない):

```bash
curl -s -H 'Accept-Language: ja' https://jervis.vercel.app/ \
  | grep -o '"initialI18nStore":{"ja":{"common":{[^}]*' | head -c 200
```

`common` が非空なら修正が効いている。
