### PR TITLE
端数hitsのカットインが常に切り上げ回数で計算されていたのを修正

### DIFF
--- a/crates/fleethub-core/src/analyzer/damage_report.rs
+++ b/crates/fleethub-core/src/analyzer/damage_report.rs
@@ -189,7 +189,7 @@ mod test {
                 total: 0.3,
             }),
             hits,
-            is_cutin: false,
+            is_cutin: true,
         }
     }
 

--- a/crates/fleethub-core/src/analyzer/damage_report.rs
+++ b/crates/fleethub-core/src/analyzer/damage_report.rs
@@ -151,7 +151,9 @@ impl<'a> DamageAnalyzer<'a> {
                 })
                 .collect::<Histogram<u16, f64>>();
 
-            if h == max_hits && max_hits_rate > 0.0 {
+            // hits が端数のときは、切り捨て回数と切り上げ回数を小数部の比率で混ぜる。
+            // 例: hits = 1.65 なら 1回が 35%、2回が 65%。最後の畳み込みでのみ行う。
+            if h == max_hits - 1 && max_hits_rate > 0.0 {
                 density1 = density1 * (1.0 - max_hits_rate) + density2 * max_hits_rate;
             } else {
                 density1 = density2
@@ -165,6 +167,83 @@ impl<'a> DamageAnalyzer<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn attack(hits: f64, current_hp: u16) -> Attack {
+        Attack {
+            attack_power: Some(AttackPower {
+                normal: 1000.0,
+                critical: 1500.0,
+                remaining_ammo_mod: 1.0,
+                ..Default::default()
+            }),
+            defense_params: Some(DefenseParams {
+                basic_defense_power: 500.0,
+                current_hp,
+                max_hp: current_hp,
+                sinkable: true,
+                overkill_protection: false,
+            }),
+            hit_rate: Some(HitRate {
+                normal: 0.2,
+                critical: 0.1,
+                total: 0.3,
+            }),
+            hits,
+            is_cutin: false,
+        }
+    }
+
+    fn density_of(hits: f64, current_hp: u16) -> Histogram<u16, f64> {
+        DamageReport::new(&attack(hits, current_hp))
+            .unwrap()
+            .damage_density
+    }
+
+    fn assert_close(left: &Histogram<u16, f64>, right: &Histogram<u16, f64>, label: &str) {
+        let keys = left.keys().chain(right.keys()).copied().collect::<Vec<_>>();
+
+        for key in keys {
+            let a = left.get(&key).copied().unwrap_or(0.0);
+            let b = right.get(&key).copied().unwrap_or(0.0);
+            assert!((a - b).abs() < 1e-12, "{label}: damage {key} で {a} != {b}");
+        }
+    }
+
+    /// 端数 hits は「切り捨て回数」と「切り上げ回数」の混合になること。
+    ///
+    /// 例えば主魚電カットイン (hits = 1.65) は 1回が 35%、2回が 65%。
+    /// 作戦室のチップも `1 (35%) ~ 2 (65%)` と表示している。
+    #[test]
+    fn test_fractional_hits_is_a_mixture() {
+        for (hits, lower, upper) in [(1.5, 1.0, 2.0), (1.65, 1.0, 2.0), (2.25, 2.0, 3.0)] {
+            let current_hp = 400;
+            let rate = hits - lower;
+
+            let actual = density_of(hits, current_hp);
+            let lower_density = density_of(lower, current_hp);
+            let upper_density = density_of(upper, current_hp);
+
+            let expected = lower_density.clone() * (1.0 - rate) + upper_density.clone() * rate;
+
+            assert_close(&actual, &expected, &format!("hits={hits}"));
+
+            // 回帰テスト: 端数が無視されて切り上げ回数だけで計算されていないこと。
+            let diff = lower_density
+                .keys()
+                .chain(upper_density.keys())
+                .map(|key| {
+                    let a = actual.get(key).copied().unwrap_or(0.0);
+                    let b = upper_density.get(key).copied().unwrap_or(0.0);
+                    (a - b).abs()
+                })
+                .fold(0.0_f64, f64::max);
+
+            assert!(
+                diff > 1e-9,
+                "hits={hits} の分布が {upper} 回ぶんと同一になっている (最大差 {diff})"
+            );
+        }
+    }
 
     #[test]
     fn test_damage_report() {

--- a/crates/fleethub-core/tests/analyzer/damage_density.rs
+++ b/crates/fleethub-core/tests/analyzer/damage_density.rs
@@ -1,5 +1,5 @@
 use fleethub_core::{
-    analyzer::{AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig},
+    analyzer::{AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig, DamageReport},
     types::{AirState, Engagement, NodeState, OrgType},
 };
 
@@ -50,19 +50,37 @@ fn test_fractional_hits_night_cutin() {
 
     let damage = cutin.damage.as_ref().expect("ダメージが計算されていない");
 
-    let min_damage = damage
-        .damage_density
-        .keys()
-        .copied()
-        .min()
-        .expect("分布が空");
+    let min_of = |report: &DamageReport| {
+        report
+            .damage_density
+            .keys()
+            .copied()
+            .min()
+            .expect("分布が空")
+    };
 
-    // 1発ぶんの最小ダメージ。2回で計算されているとその2倍が下限になる。
-    let per_hit_min = damage.normal_damage_min;
+    // 同じ攻撃者・対象で発動する2回カットイン。切り上げ (2回) で計算されていた場合の
+    // 分布はこれと同じ下限になる。割合ダメージの下限は攻撃力ではなく対象の耐久で
+    // 決まるので、マスタが変わっても両者の関係は保たれる。
+    let two_hits = analysis
+        .night
+        .data
+        .get("TorpTorpMain")
+        .expect("魚雷カットインが発動していない");
+
+    assert_eq!(two_hits.hits, 2.0, "比較対象の hits が想定と違う");
+
+    let two_hits_damage = two_hits
+        .damage
+        .as_ref()
+        .expect("比較対象のダメージが計算されていない");
+
+    let min_damage = min_of(damage);
+    let two_hits_min = min_of(two_hits_damage);
 
     assert!(
-        min_damage <= per_hit_min,
-        "分布の最小ダメージが {min_damage}。1発ぶんの最小 {per_hit_min} を超えており、\
-         端数 hits が無視されて2回ぶんで計算されている"
+        min_damage < two_hits_min,
+        "分布の最小ダメージが {min_damage} で、2回カットインの {two_hits_min} を下回っていない。\
+         端数 hits が無視されて2回ぶんだけで計算されている"
     );
 }

--- a/crates/fleethub-core/tests/analyzer/damage_density.rs
+++ b/crates/fleethub-core/tests/analyzer/damage_density.rs
@@ -1,0 +1,68 @@
+use fleethub_core::{
+    analyzer::{AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig},
+    types::{AirState, Engagement, NodeState, OrgType},
+};
+
+use crate::*;
+
+/// 主魚電カットイン (hits = 1.65) が「1回 35% / 2回 65%」の混合になっていること。
+///
+/// 以前は端数を混ぜる分岐が到達不能で、常に切り上げ (2回) で計算されていた。
+/// 作戦室のチップは `1 (35%) ~ 2 (65%)` と表示しているので、表示と分布が食い違っていた。
+#[test]
+fn test_fractional_hits_night_cutin() {
+    let attacker = ship! {
+        ship_id = "島風改"
+        level = 175
+        g1 = "12.7cm連装砲C型改二"
+        g2 = "61cm四連装(酸素)魚雷"
+        g3 = "22号対水上電探改四"
+    };
+    let target = ship! {
+        ship_id = "戦艦棲姫"
+    };
+
+    let mut target_config = AttackAnalyzerShipConfig::default();
+    target_config.conditions.position.org_type = OrgType::EnemySingle;
+
+    let analyzer = AttackAnalyzer {
+        battle_defs: &battle_definitions(),
+        config: AttackAnalyzerConfig {
+            air_state: AirState::AirSupremacy,
+            engagement: Engagement::Parallel,
+            node_state: NodeState::default(),
+            attacker: AttackAnalyzerShipConfig::default(),
+            target: target_config,
+        },
+        attacker: &attacker,
+        target: &target,
+    };
+
+    let analysis = analyzer.analyze();
+
+    let cutin = analysis
+        .night
+        .data
+        .get("MainTorpRadar")
+        .expect("主魚電カットインが発動していない");
+
+    assert_eq!(cutin.hits, 1.65, "hits が想定と違う");
+
+    let damage = cutin.damage.as_ref().expect("ダメージが計算されていない");
+
+    let min_damage = damage
+        .damage_density
+        .keys()
+        .copied()
+        .min()
+        .expect("分布が空");
+
+    // 1発ぶんの最小ダメージ。2回で計算されているとその2倍が下限になる。
+    let per_hit_min = damage.normal_damage_min;
+
+    assert!(
+        min_damage <= per_hit_min,
+        "分布の最小ダメージが {min_damage}。1発ぶんの最小 {per_hit_min} を超えており、\
+         端数 hits が無視されて2回ぶんで計算されている"
+    );
+}

--- a/crates/fleethub-core/tests/analyzer/mod.rs
+++ b/crates/fleethub-core/tests/analyzer/mod.rs
@@ -1,1 +1,2 @@
 mod attacks;
+mod damage_density;


### PR DESCRIPTION
> #34 を分割した **1/7 本目**です。コミットは元のまま (ハッシュ不変) なので、
> #34 に頂いたレビューはそちらに残っています。

<details><summary>分割の全体像</summary>

| | 内容 | ブランチ | 前提 |
| --- | --- | --- | --- |
| 1 | 端数hitsのカットイン修正 | `fix/fractional-hits-cutin` | なし |
| 2 | 翻訳キー追加 / dev の翻訳リロード | `fix/locale-i18n-fixes` | なし (独立) |
| 3 | ダメージ分布の計算を高速化 | `perf/damage-density` | 1 |
| 4 | 割合ダメージだけの分布 | `feat/damage-density-mode` | 3 |
| 5 | 集計と軸の組み立て (TS) | `feat/damage-density-utils` | 4 |
| 6 | 図の本体 (TS) | `feat/damage-density-chart-view` | 5 |
| 7 | ダメージ計算画面への組み込み | `feature/damage-density-chart` (#34) | 6 |

</details>

前提が先にマージされてからレビューをお願いします。上段は develop の更新に追随して rebase します。

## 端数 hits のカットインが常に切り上げ回数で計算されていた

`DamageAnalyzer::density` の混合分岐が到達不能でした。ループが `for h in 1..max_hits` なので
`h == max_hits` は成立せず、小数部 (`max_hits_rate`) が一度も適用されていません。

その結果、hits が端数のカットインは**常に切り上げ回数**で計算されていました。影響するのは
MainTorpRadar 1.65 / TorpLookoutRadar 1.5 / TorpTsloTorp 1.875 / TorpTsloDrum 1.55 の4種で、
いずれも夜戦の主力です。ダメージを過大評価していました。

`AttackStyleChip` は同じ値を `1 (35%) ~ 2 (65%)` と表示しているので、表示と分布が食い違って
いたことになります。

## テスト

回帰テストを2つ追加しました。

- 単体 — 端数 hits の分布が、切り捨て回数と切り上げ回数の混合に一致すること
- 統合 — 実データの主魚電で、分布の最小ダメージが1発ぶんの最小以下であること
  (2回ぶんで計算されていると2倍が下限になる)

## レビュー観点

この PR だけは**表示済みの数値が変わります**。スタックの他の6本は挙動を変えないので、
急ぐならこれだけ先に取り込めます。
