### PR TITLE
装甲を貫通しなかった場合の分布を DamageReport から出せるようにする

### DIFF
--- a/crates/fleethub-core/src/analyzer.rs
+++ b/crates/fleethub-core/src/analyzer.rs
@@ -65,6 +65,7 @@ impl Analyzer {
             config,
             attacker,
             target,
+            density_detail: DensityDetail::Total,
         };
 
         analyzer.analyze()
@@ -77,6 +78,7 @@ impl Analyzer {
         left_ship: &Ship,
         right_comp: &Comp,
         right_ship: &Ship,
+        density_detail: Option<DensityDetail>,
     ) -> NodeAttackAnalysis {
         let analyzer = NodeAttackAnalyzer {
             battle_defs: &self.battle_defs,
@@ -85,6 +87,7 @@ impl Analyzer {
             left_ship,
             right_comp,
             right_ship,
+            density_detail: density_detail.unwrap_or_default(),
         };
 
         analyzer.analyze()

--- a/crates/fleethub-core/src/analyzer/attack_analyzer.rs
+++ b/crates/fleethub-core/src/analyzer/attack_analyzer.rs
@@ -3,8 +3,8 @@ use tsify::Tsify;
 
 use crate::{
     attack::{
-        AswAttackParams, DayPhaseAttackParams, NightPhaseAttackParams, SupportShellingAttackParams,
-        TorpedoAttackParams,
+        AswAttackParams, AttackParams, DayPhaseAttackParams, NightPhaseAttackParams,
+        SupportShellingAttackParams, TorpedoAttackParams,
     },
     member::BattleMemberRef,
     ship::{NightCutinTermParams, Ship},
@@ -17,13 +17,14 @@ use crate::{
     utils::some_or_return,
 };
 
-use super::{ActionReport, AttackAnalyzerConfig, AttackReport};
+use super::{ActionReport, AttackAnalyzerConfig, AttackReport, DensityDetail};
 
 pub struct AttackAnalyzer<'a> {
     pub battle_defs: &'a BattleDefinitions,
     pub config: AttackAnalyzerConfig,
     pub attacker: &'a Ship,
     pub target: &'a Ship,
+    pub density_detail: DensityDetail,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
@@ -42,6 +43,10 @@ pub struct AttackAnalysis {
 }
 
 impl AttackAnalyzer<'_> {
+    fn report<T>(&self, style: T, proc_rate: Option<f64>, params: AttackParams) -> AttackReport<T> {
+        AttackReport::with_density_detail(style, proc_rate, params, self.density_detail)
+    }
+
     pub fn analyze(&self) -> AttackAnalysis {
         let day = self.analyze_day_phase_action();
         let night = self.analyze_night_phase_action();
@@ -176,7 +181,7 @@ impl AttackAnalyzer<'_> {
         }
         .calc_attack_params();
 
-        AttackReport::new(style, proc_rate, attack_params)
+        self.report(style, proc_rate, attack_params)
     }
 
     pub fn analyze_day_phase_action(&self) -> ActionReport<DayPhaseAttackStyle> {
@@ -214,7 +219,7 @@ impl AttackAnalyzer<'_> {
                 }
                 .calc_attack_params();
 
-                AttackReport::new(style, proc_rate, attack_params)
+                self.report(style, proc_rate, attack_params)
             })
             .collect();
 
@@ -252,7 +257,7 @@ impl AttackAnalyzer<'_> {
                     night_conditions,
                 }
                 .calc_attack_params();
-                AttackReport::new(style, proc_rate, attack_params)
+                self.report(style, proc_rate, attack_params)
             })
             .collect::<Vec<_>>();
 
@@ -352,7 +357,7 @@ impl AttackAnalyzer<'_> {
         }
         .calc_attack_params();
 
-        ActionReport::one(style, params)
+        ActionReport::new(vec![self.report(style, Some(1.0), params)])
     }
 
     fn analyze_opening_asw(&self) -> ActionReport<AswAttackStyle> {
@@ -385,7 +390,7 @@ impl AttackAnalyzer<'_> {
         }
         .calc_attack_params();
 
-        ActionReport::one(style, params)
+        ActionReport::new(vec![self.report(style, Some(1.0), params)])
     }
 
     fn analyze_support_shelling(&self) -> ActionReport<SupportShellingStyle> {
@@ -413,6 +418,6 @@ impl AttackAnalyzer<'_> {
         .calc_attack_params();
 
         let style = SupportShellingStyle { attack_type };
-        ActionReport::one(style, params)
+        ActionReport::new(vec![self.report(style, Some(1.0), params)])
     }
 }

--- a/crates/fleethub-core/src/analyzer/attack_report.rs
+++ b/crates/fleethub-core/src/analyzer/attack_report.rs
@@ -3,7 +3,7 @@ use tsify::Tsify;
 
 use crate::attack::{Attack, AttackParams, AttackPower, AttackPowerParams, HitRate, HitRateParams};
 
-use super::DamageReport;
+use super::{DamageReport, DensityDetail};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 pub struct AttackReport<T> {
@@ -19,8 +19,17 @@ pub struct AttackReport<T> {
 
 impl<T> AttackReport<T> {
     pub fn new(style: T, proc_rate: Option<f64>, params: AttackParams) -> Self {
+        Self::with_density_detail(style, proc_rate, params, DensityDetail::Total)
+    }
+
+    pub fn with_density_detail(
+        style: T,
+        proc_rate: Option<f64>,
+        params: AttackParams,
+        detail: DensityDetail,
+    ) -> Self {
         let attack = params.calc_attack();
-        let damage = DamageReport::new(&attack);
+        let damage = DamageReport::new(&attack, detail);
 
         let AttackParams {
             attack_power_params,

--- a/crates/fleethub-core/src/analyzer/damage_report.rs
+++ b/crates/fleethub-core/src/analyzer/damage_report.rs
@@ -2,11 +2,20 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
 use crate::{
-    attack::{Attack, AttackPower, HitRate},
+    attack::{add_at, Attack, AttackPower, HitRate},
     attack::{Damage, DefenseParams, DensityMode, HitType},
     types::DamageState,
     utils::Histogram,
 };
+
+/// `DamageReport` にどこまでの分布を持たせるか。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[tsify(from_wasm_abi)]
+pub enum DensityDetail {
+    #[default]
+    Total,
+    WithNoPenetration,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
 pub struct DamageReport {
@@ -19,18 +28,20 @@ pub struct DamageReport {
     pub normal_scratch_rate: f64,
     pub critical_scratch_rate: f64,
     pub damage_density: Histogram<u16, f64>,
-    /// 全弾が割合ダメージ（カスダメ）だった場合の分布。総和はその確率なので 1 未満。
+    /// 1発も装甲を貫通しなかった場合の分布。`damage_density` との差が
+    /// 「少なくとも1発貫通した場合」になる。
     ///
-    /// `damage_density` から引けば、貫通が1発でも混ざった分と分けられる。
-    /// 割合ダメージを 0 ダメージ扱いにした分布との差では取り出せない。多段攻撃で
-    /// 「割合＋貫通」の結果が貫通ぶんだけ大きなダメージ値へ動くためで、
-    /// その位置まで割合として数えてしまう。
-    pub damage_density_scratch_only: Histogram<u16, f64>,
+    /// 割合ダメージを 0 ダメージ扱いにした分布との差では代わりにならない。多段では
+    /// 「割合＋貫通」の結果が貫通ぶんだけ大きなダメージ値へ動くので、その位置まで
+    /// 割合として数えてしまう。
+    ///
+    /// 両者は加算順が違うため、差は丸め誤差の幅で負になり得る。
+    pub damage_density_no_penetration: Option<Histogram<u16, f64>>,
     pub damage_state_density: Histogram<DamageState, f64>,
 }
 
 impl DamageReport {
-    pub fn new(attack: &Attack) -> Option<Self> {
+    pub fn new(attack: &Attack, detail: DensityDetail) -> Option<Self> {
         let hits = attack.hits;
         let is_cutin = attack.is_cutin;
         let attack_power = attack.attack_power.as_ref()?;
@@ -77,7 +88,8 @@ impl DamageReport {
         };
 
         let damage_density = analyze(DensityMode::All);
-        let damage_density_scratch_only = analyze(DensityMode::ScratchOnly);
+        let damage_density_no_penetration = (detail == DensityDetail::WithNoPenetration)
+            .then(|| analyze(DensityMode::NoPenetration));
 
         let &DefenseParams {
             current_hp, max_hp, ..
@@ -103,7 +115,7 @@ impl DamageReport {
             normal_scratch_rate,
             critical_scratch_rate,
             damage_density,
-            damage_density_scratch_only,
+            damage_density_no_penetration,
             damage_state_density,
         })
     }
@@ -114,8 +126,8 @@ impl DamageReport {
 enum StepSource {
     /// 命中種別ごとに防御力サンプルを振り分ける。
     HitRate,
-    /// 割合ダメージの値だけを、あらかじめ求めた確率で書き出す。
-    ScratchWeight(f64),
+    /// 貫通しなかった結果を、命中種別をまとめた確率で書き出す。
+    NoPenetration { miss: f64, scratch: f64 },
 }
 
 struct DamageAnalyzer<'a> {
@@ -145,9 +157,10 @@ impl<'a> DamageAnalyzer<'a> {
         out.clear();
 
         match source {
-            StepSource::ScratchWeight(weight) => {
+            StepSource::NoPenetration { miss, scratch } => {
+                add_at(out, 0, miss);
                 self.to_damage(HitType::Normal, current_hp)
-                    .add_scratch_density_to(out, weight);
+                    .add_scratch_density_to(out, scratch);
             }
             StepSource::HitRate => {
                 for (hit_type, rate) in self.hit_rate.iter() {
@@ -162,20 +175,27 @@ impl<'a> DamageAnalyzer<'a> {
         }
     }
 
-    fn scratch_weight(&self, current_hp: u16) -> f64 {
-        self.hit_rate
+    fn no_penetration_source(&self) -> StepSource {
+        let current_hp = self.defense_params.current_hp;
+
+        let miss_rate = 1.0 - self.hit_rate.total;
+        let miss_scratch_rate = self.to_damage(HitType::Miss, current_hp).scratch_rate();
+        let miss = miss_rate * (1.0 - miss_scratch_rate);
+
+        let scratch = self
+            .hit_rate
             .iter()
             .filter(|(_, rate)| *rate != 0.0)
             .map(|(hit_type, rate)| rate * self.to_damage(hit_type, current_hp).scratch_rate())
-            .sum()
+            .sum();
+
+        StepSource::NoPenetration { miss, scratch }
     }
 
     fn step_source(&self) -> StepSource {
         match self.mode {
             DensityMode::All => StepSource::HitRate,
-            DensityMode::ScratchOnly => {
-                StepSource::ScratchWeight(self.scratch_weight(self.defense_params.current_hp))
-            }
+            DensityMode::NoPenetration => self.no_penetration_source(),
         }
     }
 
@@ -316,28 +336,38 @@ mod test {
         }
     }
 
+    fn no_penetration_of(attack: &Attack) -> (Histogram<u16, f64>, Histogram<u16, f64>) {
+        let report = DamageReport::new(attack, DensityDetail::WithNoPenetration).unwrap();
+        (
+            report.damage_density,
+            report.damage_density_no_penetration.unwrap(),
+        )
+    }
+
     #[test]
-    fn test_damage_density_scratch_only() {
+    fn test_no_penetration_is_computed_only_on_request() {
+        let report = DamageReport::new(&mixed_attack(2.0, 99), DensityDetail::Total).unwrap();
+        assert!(report.damage_density_no_penetration.is_none());
+    }
+
+    #[test]
+    fn test_damage_density_no_penetration() {
         for hits in [1.0, 2.0, 1.65] {
             for current_hp in [99u16, 50, 10] {
-                let report = DamageReport::new(&mixed_attack(hits, current_hp)).unwrap();
-                let all = &report.damage_density;
-                let scratch_only = &report.damage_density_scratch_only;
+                let (all, no_penetration) = no_penetration_of(&mixed_attack(hits, current_hp));
 
                 let label = format!("hits={hits} hp={current_hp}");
                 let probability = |h: &Histogram<u16, f64>| h.values().sum::<f64>();
 
-                assert!(report.normal_scratch_rate > 0.0, "{label}");
-
-                let all_scratch_probability = probability(scratch_only);
-                assert!(all_scratch_probability > 0.0, "{label}");
+                let no_penetration_probability = probability(&no_penetration);
+                assert!(no_penetration_probability > 0.0, "{label}");
                 assert!(
-                    all_scratch_probability < probability(all) - 1e-12,
+                    no_penetration_probability < probability(&all) - 1e-12,
                     "{label}"
                 );
 
-                // 図では合計の棒を割合ぶんで塗り分ける。食み出すと下の段が負になる。
-                for (damage, rate) in scratch_only.iter() {
+                // 図では合計の棒を貫通なしのぶんで塗り分ける。食み出すと下の段が負になる。
+                for (damage, rate) in no_penetration.iter() {
                     let total = all.get(damage).copied().unwrap_or(0.0);
                     assert!(*rate <= total + 1e-12, "{label} damage={damage}");
                 }
@@ -352,7 +382,7 @@ mod test {
                     hp = hp.saturating_sub(step);
                 }
 
-                let max_damage = scratch_only.keys().copied().max().unwrap_or(0);
+                let max_damage = no_penetration.keys().copied().max().unwrap_or(0);
                 assert!(
                     max_damage <= all_scratch_max,
                     "{label} {max_damage} > {all_scratch_max}"
@@ -371,9 +401,52 @@ mod test {
         }
     }
 
-    /// 割合ダメージの近道が、防御力サンプルを毎段走査する一般の経路と一致すること。
     #[test]
-    fn test_scratch_only_shortcut_matches_general_path() {
+    fn test_no_penetration_equals_all_when_armor_is_never_penetrated() {
+        let attack = Attack {
+            attack_power: Some(AttackPower {
+                normal: 100.0,
+                critical: 100.0,
+                remaining_ammo_mod: 1.0,
+                ..Default::default()
+            }),
+            defense_params: Some(DefenseParams {
+                basic_defense_power: 500.0,
+                current_hp: 100,
+                max_hp: 100,
+                sinkable: true,
+                overkill_protection: false,
+            }),
+            hit_rate: Some(HitRate {
+                normal: 0.5,
+                critical: 0.0,
+                total: 0.5,
+            }),
+            hits: 2.0,
+            is_cutin: false,
+        };
+
+        let (all, no_penetration) = no_penetration_of(&attack);
+        assert_close(&no_penetration, &all, "ミスと割合ダメージしか起きない");
+    }
+
+    #[test]
+    fn test_no_penetration_keeps_plain_misses() {
+        let mut attack = attack(2.0, 400);
+        attack.is_cutin = false;
+
+        let miss_rate = 1.0 - attack.hit_rate.as_ref().unwrap().total;
+        let (_, no_penetration) = no_penetration_of(&attack);
+
+        assert_close(
+            &no_penetration,
+            &[(0, miss_rate * miss_rate)].into_iter().collect(),
+            "必ず貫通する攻撃では、全弾ミスだけが残る",
+        );
+    }
+
+    #[test]
+    fn test_no_penetration_shortcut_matches_general_path() {
         for hits in [1.0, 2.0, 3.0, 1.65] {
             for current_hp in [6000u16, 400, 99, 17, 10, 1] {
                 for is_cutin in [false, true] {
@@ -386,7 +459,7 @@ mod test {
                         hit_rate: attack.hit_rate.as_ref().unwrap(),
                         hits,
                         is_cutin,
-                        mode: DensityMode::ScratchOnly,
+                        mode: DensityMode::NoPenetration,
                     };
 
                     let label = format!("hits={hits} hp={current_hp} cutin={is_cutin}");
@@ -401,7 +474,7 @@ mod test {
     }
 
     fn density_of(hits: f64, current_hp: u16) -> Histogram<u16, f64> {
-        DamageReport::new(&attack(hits, current_hp))
+        DamageReport::new(&attack(hits, current_hp), DensityDetail::Total)
             .unwrap()
             .damage_density
     }
@@ -678,12 +751,11 @@ mod test {
             let after = run("最適化後", &|| analyzer.density(), 20);
             println!("    短縮率     {:>9.1} 倍", before / after);
 
-            // DamageReport::new は 2 モードぶん引くので、その内訳。
             let with_mode = |mode: DensityMode| DamageAnalyzer { mode, ..analyzer };
-            run("うち All", &|| with_mode(DensityMode::All).density(), 20);
+            run("All", &|| with_mode(DensityMode::All).density(), 20);
             run(
-                "うち 割合のみ",
-                &|| with_mode(DensityMode::ScratchOnly).density(),
+                "貫通なし",
+                &|| with_mode(DensityMode::NoPenetration).density(),
                 20,
             );
         }
@@ -716,7 +788,7 @@ mod test {
             is_cutin: false,
         };
 
-        let result = DamageReport::new(&attack).unwrap();
+        let result = DamageReport::new(&attack, DensityDetail::Total).unwrap();
 
         assert!(result.damage_density.iter().count() < 3000);
 

--- a/crates/fleethub-core/src/analyzer/damage_report.rs
+++ b/crates/fleethub-core/src/analyzer/damage_report.rs
@@ -422,7 +422,7 @@ mod test {
                 critical: 0.0,
                 total: 0.5,
             }),
-            hits: 2.0,
+            hits: 1.0,
             is_cutin: false,
         };
 
@@ -432,7 +432,7 @@ mod test {
 
     #[test]
     fn test_no_penetration_keeps_plain_misses() {
-        let mut attack = attack(2.0, 400);
+        let mut attack = attack(1.0, 400);
         attack.is_cutin = false;
 
         let miss_rate = 1.0 - attack.hit_rate.as_ref().unwrap().total;
@@ -440,8 +440,8 @@ mod test {
 
         assert_close(
             &no_penetration,
-            &[(0, miss_rate * miss_rate)].into_iter().collect(),
-            "必ず貫通する攻撃では、全弾ミスだけが残る",
+            &[(0, miss_rate)].into_iter().collect(),
+            "必ず貫通する攻撃では、ミスだけが残る",
         );
     }
 

--- a/crates/fleethub-core/src/analyzer/damage_report.rs
+++ b/crates/fleethub-core/src/analyzer/damage_report.rs
@@ -3,7 +3,7 @@ use tsify::Tsify;
 
 use crate::{
     attack::{Attack, AttackPower, HitRate},
-    attack::{Damage, DefenseParams, HitType},
+    attack::{Damage, DefenseParams, DensityMode, HitType},
     types::DamageState,
     utils::Histogram,
 };
@@ -19,6 +19,13 @@ pub struct DamageReport {
     pub normal_scratch_rate: f64,
     pub critical_scratch_rate: f64,
     pub damage_density: Histogram<u16, f64>,
+    /// 全弾が割合ダメージ（カスダメ）だった場合の分布。総和はその確率なので 1 未満。
+    ///
+    /// `damage_density` から引けば、貫通が1発でも混ざった分と分けられる。
+    /// 割合ダメージを 0 ダメージ扱いにした分布との差では取り出せない。多段攻撃で
+    /// 「割合＋貫通」の結果が貫通ぶんだけ大きなダメージ値へ動くためで、
+    /// その位置まで割合として数えてしまう。
+    pub damage_density_scratch_only: Histogram<u16, f64>,
     pub damage_state_density: Histogram<DamageState, f64>,
 }
 
@@ -51,20 +58,26 @@ impl DamageReport {
         let normal_scratch_rate = normal.scratch_rate();
         let critical_scratch_rate = critical.scratch_rate();
 
-        let damage_density = attack
-            .hit_rate
-            .as_ref()
-            .map(|hit_rate| {
-                DamageAnalyzer {
-                    attack_power,
-                    defense_params,
-                    hit_rate,
-                    hits,
-                    is_cutin,
-                }
-                .density()
-            })
-            .unwrap_or_default();
+        let analyze = |mode: DensityMode| {
+            attack
+                .hit_rate
+                .as_ref()
+                .map(|hit_rate| {
+                    DamageAnalyzer {
+                        attack_power,
+                        defense_params,
+                        hit_rate,
+                        hits,
+                        is_cutin,
+                        mode,
+                    }
+                    .density()
+                })
+                .unwrap_or_default()
+        };
+
+        let damage_density = analyze(DensityMode::All);
+        let damage_density_scratch_only = analyze(DensityMode::ScratchOnly);
 
         let &DefenseParams {
             current_hp, max_hp, ..
@@ -90,9 +103,19 @@ impl DamageReport {
             normal_scratch_rate,
             critical_scratch_rate,
             damage_density,
+            damage_density_scratch_only,
             damage_state_density,
         })
     }
+}
+
+/// 1段ぶんの分布を何から書き出すか。
+#[derive(Debug, Clone, Copy)]
+enum StepSource {
+    /// 命中種別ごとに防御力サンプルを振り分ける。
+    HitRate,
+    /// 割合ダメージの値だけを、あらかじめ求めた確率で書き出す。
+    ScratchWeight(f64),
 }
 
 struct DamageAnalyzer<'a> {
@@ -101,6 +124,7 @@ struct DamageAnalyzer<'a> {
     defense_params: &'a DefenseParams,
     is_cutin: bool,
     hits: f64,
+    mode: DensityMode,
 }
 
 impl<'a> DamageAnalyzer<'a> {
@@ -117,24 +141,49 @@ impl<'a> DamageAnalyzer<'a> {
         }
     }
 
-    /// 1回ぶんの攻撃のダメージ分布を、ダメージ値を添字とする密な配列に書き出す。
-    ///
-    /// 多段攻撃では被弾するたびに残耐久が変わり、割合ダメージと撃沈保護ダメージが
-    /// 残耐久に比例するため、段ごとに引き直す必要がある。
-    fn once_dense(&self, current_hp: u16, out: &mut Vec<f64>) {
+    fn write_step(&self, current_hp: u16, out: &mut Vec<f64>, source: StepSource) {
         out.clear();
 
-        for (hit_type, rate) in self.hit_rate.iter() {
-            if rate == 0.0 {
-                continue;
+        match source {
+            StepSource::ScratchWeight(weight) => {
+                self.to_damage(HitType::Normal, current_hp)
+                    .add_scratch_density_to(out, weight);
             }
+            StepSource::HitRate => {
+                for (hit_type, rate) in self.hit_rate.iter() {
+                    if rate == 0.0 {
+                        continue;
+                    }
 
-            self.to_damage(hit_type, current_hp)
-                .add_density_to(out, rate);
+                    self.to_damage(hit_type, current_hp)
+                        .add_density_to(out, rate, self.mode);
+                }
+            }
+        }
+    }
+
+    fn scratch_weight(&self, current_hp: u16) -> f64 {
+        self.hit_rate
+            .iter()
+            .filter(|(_, rate)| *rate != 0.0)
+            .map(|(hit_type, rate)| rate * self.to_damage(hit_type, current_hp).scratch_rate())
+            .sum()
+    }
+
+    fn step_source(&self) -> StepSource {
+        match self.mode {
+            DensityMode::All => StepSource::HitRate,
+            DensityMode::ScratchOnly => {
+                StepSource::ScratchWeight(self.scratch_weight(self.defense_params.current_hp))
+            }
         }
     }
 
     fn density(&self) -> Histogram<u16, f64> {
+        self.density_from(self.step_source())
+    }
+
+    fn density_from(&self, source: StepSource) -> Histogram<u16, f64> {
         let hp1 = self.defense_params.current_hp;
 
         // 畳み込みはハッシュマップではなく密な配列で行う。ダメージ値をそのまま
@@ -146,12 +195,12 @@ impl<'a> DamageAnalyzer<'a> {
         // `calc_damage_type` の `as u16` で 65535 に飽和するため、配列長は
         // `ceil(hits) * 65536` (約 1.6MB) で頭打ちになる。
         let mut density1 = Vec::new();
-        self.once_dense(hp1, &mut density1);
+        self.write_step(hp1, &mut density1, source);
 
         if self.hits > 1.0 {
             let max_hits = self.hits.ceil() as usize;
             let max_hits_rate = self.hits.fract();
-            let mut once_buf = Vec::new();
+            let mut step_buf = Vec::new();
 
             for h in 1..max_hits {
                 let mut density2 = vec![0.0; density1.len()];
@@ -164,14 +213,14 @@ impl<'a> DamageAnalyzer<'a> {
                     }
 
                     let hp2 = hp1.saturating_sub(damage_value1 as u16);
-                    self.once_dense(hp2, &mut once_buf);
+                    self.write_step(hp2, &mut step_buf, source);
 
-                    let required = damage_value1 + once_buf.len();
+                    let required = damage_value1 + step_buf.len();
                     if density2.len() < required {
                         density2.resize(required, 0.0);
                     }
 
-                    for (damage_value2, rate2) in once_buf.iter().enumerate() {
+                    for (damage_value2, rate2) in step_buf.iter().enumerate() {
                         if *rate2 != 0.0 {
                             density2[damage_value1 + damage_value2] += rate1 * rate2;
                         }
@@ -238,6 +287,116 @@ mod test {
             }),
             hits,
             is_cutin: true,
+        }
+    }
+
+    /// 装甲を抜けたり抜けなかったりする攻撃。割合ダメージと実ダメージが混ざる。
+    fn mixed_attack(hits: f64, current_hp: u16) -> Attack {
+        Attack {
+            attack_power: Some(AttackPower {
+                normal: 550.0,
+                critical: 800.0,
+                remaining_ammo_mod: 1.0,
+                ..Default::default()
+            }),
+            defense_params: Some(DefenseParams {
+                basic_defense_power: 500.0,
+                current_hp,
+                max_hp: current_hp,
+                sinkable: true,
+                overkill_protection: false,
+            }),
+            hit_rate: Some(HitRate {
+                normal: 0.6,
+                critical: 0.1,
+                total: 0.7,
+            }),
+            hits,
+            is_cutin: false,
+        }
+    }
+
+    #[test]
+    fn test_damage_density_scratch_only() {
+        for hits in [1.0, 2.0, 1.65] {
+            for current_hp in [99u16, 50, 10] {
+                let report = DamageReport::new(&mixed_attack(hits, current_hp)).unwrap();
+                let all = &report.damage_density;
+                let scratch_only = &report.damage_density_scratch_only;
+
+                let label = format!("hits={hits} hp={current_hp}");
+                let probability = |h: &Histogram<u16, f64>| h.values().sum::<f64>();
+
+                assert!(report.normal_scratch_rate > 0.0, "{label}");
+
+                let all_scratch_probability = probability(scratch_only);
+                assert!(all_scratch_probability > 0.0, "{label}");
+                assert!(
+                    all_scratch_probability < probability(all) - 1e-12,
+                    "{label}"
+                );
+
+                // 図では合計の棒を割合ぶんで塗り分ける。食み出すと下の段が負になる。
+                for (damage, rate) in scratch_only.iter() {
+                    let total = all.get(damage).copied().unwrap_or(0.0);
+                    assert!(*rate <= total + 1e-12, "{label} damage={damage}");
+                }
+
+                let once_max = |hp: u16| (hp as f64 * 0.06 + (hp.max(1) - 1) as f64 * 0.08) as u16;
+
+                let mut all_scratch_max = 0_u16;
+                let mut hp = current_hp;
+                for _ in 0..hits.ceil() as usize {
+                    let step = once_max(hp);
+                    all_scratch_max += step;
+                    hp = hp.saturating_sub(step);
+                }
+
+                let max_damage = scratch_only.keys().copied().max().unwrap_or(0);
+                assert!(
+                    max_damage <= all_scratch_max,
+                    "{label} {max_damage} > {all_scratch_max}"
+                );
+
+                // 多段では「割合＋貫通」の結果がこの上限より右へ動く。だから合計を
+                // 上限で切っても割合は取り出せず、専用の分布が要る。
+                if hits > 1.0 {
+                    let moved_beyond = all
+                        .iter()
+                        .any(|(damage, rate)| *damage > all_scratch_max && *rate > 1e-12);
+
+                    assert!(moved_beyond, "{label}");
+                }
+            }
+        }
+    }
+
+    /// 割合ダメージの近道が、防御力サンプルを毎段走査する一般の経路と一致すること。
+    #[test]
+    fn test_scratch_only_shortcut_matches_general_path() {
+        for hits in [1.0, 2.0, 3.0, 1.65] {
+            for current_hp in [6000u16, 400, 99, 17, 10, 1] {
+                for is_cutin in [false, true] {
+                    let mut attack = mixed_attack(hits, current_hp);
+                    attack.is_cutin = is_cutin;
+
+                    let analyzer = DamageAnalyzer {
+                        attack_power: attack.attack_power.as_ref().unwrap(),
+                        defense_params: attack.defense_params.as_ref().unwrap(),
+                        hit_rate: attack.hit_rate.as_ref().unwrap(),
+                        hits,
+                        is_cutin,
+                        mode: DensityMode::ScratchOnly,
+                    };
+
+                    let label = format!("hits={hits} hp={current_hp} cutin={is_cutin}");
+                    assert_close(
+                        &analyzer.density_from(analyzer.step_source()),
+                        &analyzer.density_from(StepSource::HitRate),
+                        &label,
+                    );
+                }
+            }
         }
     }
 
@@ -344,32 +503,6 @@ mod test {
         }
     }
 
-    /// 装甲を抜けたり抜けなかったりする攻撃。割合ダメージと実ダメージが混ざる。
-    fn mixed_attack(hits: f64, current_hp: u16) -> Attack {
-        Attack {
-            attack_power: Some(AttackPower {
-                normal: 550.0,
-                critical: 800.0,
-                remaining_ammo_mod: 1.0,
-                ..Default::default()
-            }),
-            defense_params: Some(DefenseParams {
-                basic_defense_power: 500.0,
-                current_hp,
-                max_hp: current_hp,
-                sinkable: true,
-                overkill_protection: false,
-            }),
-            hit_rate: Some(HitRate {
-                normal: 0.6,
-                critical: 0.1,
-                total: 0.7,
-            }),
-            hits,
-            is_cutin: false,
-        }
-    }
-
     /// 密な配列による畳み込みが、素朴なハッシュマップ実装と一致すること。
     ///
     /// `add_density_to` は命中種別ごとに Actual / Scratch / OverkillProtection へ
@@ -412,6 +545,7 @@ mod test {
                 hit_rate: a.hit_rate.as_ref().unwrap(),
                 hits,
                 is_cutin: a.is_cutin,
+                mode: DensityMode::All,
             };
 
             let actual = analyzer.density();
@@ -518,6 +652,7 @@ mod test {
                 hit_rate: a.hit_rate.as_ref().unwrap(),
                 hits: a.hits,
                 is_cutin: a.is_cutin,
+                mode: DensityMode::All,
             };
 
             let points = analyzer.density().len();
@@ -542,6 +677,15 @@ mod test {
             let before = run("最適化前", &|| naive(&analyzer), 3);
             let after = run("最適化後", &|| analyzer.density(), 20);
             println!("    短縮率     {:>9.1} 倍", before / after);
+
+            // DamageReport::new は 2 モードぶん引くので、その内訳。
+            let with_mode = |mode: DensityMode| DamageAnalyzer { mode, ..analyzer };
+            run("うち All", &|| with_mode(DensityMode::All).density(), 20);
+            run(
+                "うち 割合のみ",
+                &|| with_mode(DensityMode::ScratchOnly).density(),
+                20,
+            );
         }
     }
 

--- a/crates/fleethub-core/src/analyzer/day_cutin_analyzer.rs
+++ b/crates/fleethub-core/src/analyzer/day_cutin_analyzer.rs
@@ -11,7 +11,9 @@ use crate::{
     utils::some_or_return,
 };
 
-use super::{ActionReport, AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig};
+use super::{
+    ActionReport, AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig, DensityDetail,
+};
 
 pub struct DayCutinAnalyzer<'a> {
     pub battle_defs: &'a BattleDefinitions,
@@ -76,6 +78,7 @@ impl DayCutinAnalyzer<'_> {
             },
             attacker: ship,
             target: self.dummy,
+            density_detail: DensityDetail::Total,
         };
 
         let observation_term = attack_analyzer.calc_observation_term();

--- a/crates/fleethub-core/src/analyzer/night_cutin_analyzer.rs
+++ b/crates/fleethub-core/src/analyzer/night_cutin_analyzer.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     ActionReport, AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig,
-    CompAnalyzerConfig,
+    CompAnalyzerConfig, DensityDetail,
 };
 
 #[derive(Serialize, Tsify)]
@@ -63,6 +63,7 @@ impl NightCutinAnalyzer<'_> {
             },
             attacker: &ship,
             target: self.dummy,
+            density_detail: DensityDetail::Total,
         };
 
         let cutin_term = attack_analyzer.calc_night_cutin_term();

--- a/crates/fleethub-core/src/analyzer/node_attack_analyzer.rs
+++ b/crates/fleethub-core/src/analyzer/node_attack_analyzer.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use super::{
-    AttackAnalysis, AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig,
+    AttackAnalysis, AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig, DensityDetail,
     FleetCutinAnalyzer, FleetCutinReport,
 };
 
@@ -32,6 +32,7 @@ pub struct NodeAttackAnalyzer<'a> {
     pub left_ship: &'a Ship,
     pub right_comp: &'a Comp,
     pub right_ship: &'a Ship,
+    pub density_detail: DensityDetail,
 }
 
 impl NodeAttackAnalyzer<'_> {
@@ -122,6 +123,7 @@ impl NodeAttackAnalyzer<'_> {
             config,
             attacker: attacker_ship,
             target: target_ship,
+            density_detail: self.density_detail,
         }
         .analyze()
     }

--- a/crates/fleethub-core/src/attack/damage.rs
+++ b/crates/fleethub-core/src/attack/damage.rs
@@ -11,18 +11,14 @@ use super::{AttackPower, HitType};
 /// `add_density_to` が何を書き出すか。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DensityMode {
-    /// そのまま。割合ダメージ（カスダメ）も実際のダメージ値で入る。
     All,
-    /// 割合ダメージだった結果だけ。それ以外は書き出さないので総和は 1 未満になる。
-    ///
-    /// 多段攻撃で畳み込むと「全弾が割合ダメージだった場合」の分布になる。
-    /// `All` から差し引けば、貫通が1発でも混ざった分と分けられる。
-    ScratchOnly,
+    /// 装甲を貫通しなかった結果だけ。ミスと割合ダメージが残る。
+    NoPenetration,
 }
 
 impl DensityMode {
     fn keeps_penetration(self) -> bool {
-        self != Self::ScratchOnly
+        self == Self::All
     }
 }
 
@@ -96,8 +92,7 @@ fn add_steps(out: &mut Vec<f64>, hp: u16, a: f64, b: f64, weight: f64) {
     });
 }
 
-/// 密な確率配列の指定ダメージ値に加算する。必要なら配列を伸ばす。
-fn add_at(out: &mut Vec<f64>, value: u16, rate: f64) {
+pub(crate) fn add_at(out: &mut Vec<f64>, value: u16, rate: f64) {
     let index = value as usize;
     if out.len() <= index {
         out.resize(index + 1, 0.0);
@@ -105,8 +100,6 @@ fn add_at(out: &mut Vec<f64>, value: u16, rate: f64) {
     out[index] += rate;
 }
 
-/// 出現回数を正規化して密な確率配列に加算する。
-/// 出現回数を確率に正規化する。
 fn counts_to_density(counts: Vec<(u16, usize)>) -> Histogram<u16, f64> {
     let total: usize = counts.iter().map(|(_, count)| *count).sum();
     let total = total as f64;
@@ -376,16 +369,16 @@ impl Damage {
             return;
         }
 
-        let keeps_penetration = mode.keeps_penetration();
-
         if self.hit_type == HitType::Miss {
             if self.is_cutin {
                 self.add_scratch_density_to(out, weight);
-            } else if keeps_penetration {
+            } else {
                 add_at(out, 0, weight);
             }
             return;
         }
+
+        let keeps_penetration = mode.keeps_penetration();
 
         // 中間の `Histogram<DamageType, f64>` を作らず、防御力サンプルを直接振り分ける。
         // 判定は `calc_damage_type` のままなので分類規則は一箇所に保たれる。

--- a/crates/fleethub-core/src/attack/damage.rs
+++ b/crates/fleethub-core/src/attack/damage.rs
@@ -8,6 +8,24 @@ use crate::{
 
 use super::{AttackPower, HitType};
 
+/// `add_density_to` が何を書き出すか。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DensityMode {
+    /// そのまま。割合ダメージ（カスダメ）も実際のダメージ値で入る。
+    All,
+    /// 割合ダメージだった結果だけ。それ以外は書き出さないので総和は 1 未満になる。
+    ///
+    /// 多段攻撃で畳み込むと「全弾が割合ダメージだった場合」の分布になる。
+    /// `All` から差し引けば、貫通が1発でも混ざった分と分けられる。
+    ScratchOnly,
+}
+
+impl DensityMode {
+    fn keeps_penetration(self) -> bool {
+        self != Self::ScratchOnly
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 enum DamageType {
     Actual(u16),
@@ -26,13 +44,22 @@ enum DamageType {
 /// 補正ループが末尾まで走る。実際の呼び出しは (0.06, 0.08) と (0.5, 0.3) の
 /// 2通りだけで、どちらも飽和しない。
 fn step_counts(hp: u16, a: f64, b: f64) -> Vec<(u16, usize)> {
+    let mut out = Vec::new();
+    for_each_step(hp, a, b, |value, count| out.push((value, count)));
+    out
+}
+
+/// `step_counts` と同じ刻みを、Vec を作らずに順に渡す。
+///
+/// 多段攻撃の畳み込みでは段ごとに残耐久が変わるので、この列挙が
+/// 1回の解析で数百回走る。そのたびに Vec を確保すると割に合わない。
+fn for_each_step(hp: u16, a: f64, b: f64, mut f: impl FnMut(u16, usize)) {
     debug_assert!(b > 0.0);
 
     let n = hp.max(1) as u32;
     let base = a * hp as f64;
     let value_at = |v: u32| (base + v as f64 * b) as u16;
 
-    let mut out: Vec<(u16, usize)> = Vec::new();
     let mut v = 0_u32;
 
     while v < n {
@@ -53,11 +80,20 @@ fn step_counts(hp: u16, a: f64, b: f64) -> Vec<(u16, usize)> {
             next += 1;
         }
 
-        out.push((d, (next - v) as usize));
+        f(d, (next - v) as usize);
         v = next;
     }
+}
 
-    out
+/// `for_each_step` の刻みを確率に直して密な配列へ加算する。
+///
+/// 出現回数の総和は必ず `hp.max(1)` なので、数え上げ直さない。
+fn add_steps(out: &mut Vec<f64>, hp: u16, a: f64, b: f64, weight: f64) {
+    let total = hp.max(1) as f64;
+
+    for_each_step(hp, a, b, |value, count| {
+        add_at(out, value, count as f64 / total * weight);
+    });
 }
 
 /// 密な確率配列の指定ダメージ値に加算する。必要なら配列を伸ばす。
@@ -70,15 +106,6 @@ fn add_at(out: &mut Vec<f64>, value: u16, rate: f64) {
 }
 
 /// 出現回数を正規化して密な確率配列に加算する。
-fn add_counts(out: &mut Vec<f64>, counts: Vec<(u16, usize)>, weight: f64) {
-    let total: usize = counts.iter().map(|(_, count)| *count).sum();
-    let total = total as f64;
-
-    for (value, count) in counts {
-        add_at(out, value, count as f64 / total * weight);
-    }
-}
-
 /// 出現回数を確率に正規化する。
 fn counts_to_density(counts: Vec<(u16, usize)>) -> Histogram<u16, f64> {
     let total: usize = counts.iter().map(|(_, count)| *count).sum();
@@ -302,6 +329,14 @@ impl Damage {
         }
     }
 
+    pub(crate) fn add_scratch_density_to(&self, out: &mut Vec<f64>, weight: f64) {
+        if weight == 0.0 {
+            return;
+        }
+
+        add_steps(out, self.current_hp, 0.06, 0.08, weight);
+    }
+
     pub fn scratch_rate(&self) -> f64 {
         let defense_power_vec = self.defense_power().to_vec();
 
@@ -333,19 +368,20 @@ impl Damage {
         }
     }
 
-    /// `density()` と同じ分布を、ダメージ値を添字とする密な配列へ `weight` 倍して加算する。
-    ///
-    /// 多段攻撃の畳み込みでは1回の解析につき数百回呼ばれるため、
-    /// 中間の `Histogram` を作らずに直接書き込む。
-    pub(crate) fn add_density_to(&self, out: &mut Vec<f64>, weight: f64) {
+    /// 分類は `calc_damage_type` を `density()` と共有しているが、割合ダメージと
+    /// 撃沈保護ダメージの振り分けは二重に書き下している。両者が一致することは
+    /// `analyzer::damage_report` の `test_density_matches_naive` が見ている。
+    pub(crate) fn add_density_to(&self, out: &mut Vec<f64>, weight: f64, mode: DensityMode) {
         if weight == 0.0 {
             return;
         }
 
+        let keeps_penetration = mode.keeps_penetration();
+
         if self.hit_type == HitType::Miss {
             if self.is_cutin {
-                add_counts(out, self.scratch_damage().counts(), weight);
-            } else {
+                self.add_scratch_density_to(out, weight);
+            } else if keeps_penetration {
                 add_at(out, 0, weight);
             }
             return;
@@ -361,20 +397,26 @@ impl Damage {
 
         for value in defense_power.iter() {
             match self.calc_damage_type(value) {
-                DamageType::Actual(value) => add_at(out, value, unit),
+                DamageType::Actual(value) => {
+                    if keeps_penetration {
+                        add_at(out, value, unit)
+                    }
+                }
                 DamageType::Scratch => scratch += 1,
                 DamageType::OverkillProtection => overkill_protection += 1,
             }
         }
 
         if scratch > 0 {
-            add_counts(out, self.scratch_damage().counts(), unit * scratch as f64);
+            self.add_scratch_density_to(out, unit * scratch as f64);
         }
 
-        if overkill_protection > 0 {
-            add_counts(
+        if overkill_protection > 0 && keeps_penetration {
+            add_steps(
                 out,
-                self.overkill_protection_damage().counts(),
+                self.current_hp,
+                0.5,
+                0.3,
                 unit * overkill_protection as f64,
             );
         }

--- a/crates/fleethub-core/tests/analyzer/attacks.rs
+++ b/crates/fleethub-core/tests/analyzer/attacks.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use fleethub_core::{
-    analyzer::{AttackAnalysis, AttackAnalyzer, AttackAnalyzerConfig},
+    analyzer::{AttackAnalysis, AttackAnalyzer, AttackAnalyzerConfig, DensityDetail},
     types::{AirState, Engagement, NodeState},
 };
 
@@ -53,6 +53,7 @@ impl AttackTestCase {
             config: self.attack_analyzer_config(),
             attacker: &self.attacker.ship,
             target: &self.target.ship,
+            density_detail: DensityDetail::Total,
         };
 
         analyzer.analyze()

--- a/crates/fleethub-core/tests/analyzer/damage_density.rs
+++ b/crates/fleethub-core/tests/analyzer/damage_density.rs
@@ -1,5 +1,7 @@
 use fleethub_core::{
-    analyzer::{AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig, DamageReport},
+    analyzer::{
+        AttackAnalyzer, AttackAnalyzerConfig, AttackAnalyzerShipConfig, DamageReport, DensityDetail,
+    },
     types::{AirState, Engagement, NodeState, OrgType},
 };
 
@@ -36,6 +38,7 @@ fn test_fractional_hits_night_cutin() {
         },
         attacker: &attacker,
         target: &target,
+        density_detail: DensityDetail::Total,
     };
 
     let analysis = analyzer.analyze();


### PR DESCRIPTION
> #34 を分割した **4/7 本目**です。

<details><summary>分割の全体像</summary>

| | 内容 | ブランチ | 状態 |
| --- | --- | --- | --- |
| 1 | 端数hitsのカットイン修正 | #35 | マージ済み |
| 2 | 翻訳キー / dev の翻訳リロード | #36 | マージ済み |
| 3 | ダメージ分布の計算を高速化 | #37 | マージ済み |
| 4 | 装甲を貫通しなかった場合の分布 | `feat/damage-density-mode` | **← これ** |
| 5 | 集計と軸の組み立て (TS) | `feat/damage-density-utils` |  |
| 6 | 図の本体 (TS) | `feat/damage-density-chart-view` |  |
| 7 | ダメージ計算画面への組み込み | #34 |  |

</details>

前提が先にマージされてからレビューをお願いします。上段は develop の更新に追随して積み直します。

## 装甲を貫通しなかった場合の分布を `DamageReport` から出せるようにする

図の「割合」チェックボックスは、分布を「少なくとも1発貫通した場合」と「1発も貫通しなかった場合」
に切り分けて描きます。合計の分布だけでは切り分けられません。

割合ダメージを 0 ダメージ扱いにした分布との差では代わりになりません。多段命中では「割合＋貫通」の
結果が貫通ぶんだけ大きなダメージ値へ動くので、**その位置まで割合として数えてしまいます**。

畳み込みの段階で書き出す結果を切り替える `DensityMode` を入れました。

| | |
| --- | --- |
| `All` | そのまま |
| `NoPenetration` | 装甲を貫通しなかった結果だけ (ミスと割合ダメージ) |

`DamageReport.damage_density_no_penetration` がその分布で、`damage_density` との差が
「少なくとも1発貫通した場合」になります。

## 要求されたときだけ計算する

内訳を使うのはダメージ分布の図だけなので、`DensityDetail::WithNoPenetration` を渡したときだけ
計算し、それ以外は `None` です。wasm の `analyze_node_attack` は省略可能な引数で受け取るので、
既存の呼び出しはそのまま動きます。

## 近道

貫通しなかった結果の確率は、段ごとに数え直さず最初の段で求めた値を使い回します。1段ぶんを
「命中種別ごとに防御力サンプルを振り分ける」のか「まとめた確率で書き出す」のかは `StepSource`
が持ち、テストは `StepSource::HitRate` を直接渡して一般の経路と突き合わせています。

Rust 側の変更はここまでです。5 以降は TS だけです。
